### PR TITLE
Animation Fix (?)

### DIFF
--- a/src/components/players/PlayerStatusNotificationBox.jsx
+++ b/src/components/players/PlayerStatusNotificationBox.jsx
@@ -11,7 +11,11 @@ function PlayerStatusNotificationBox({index, isActive, content, endTransition}) 
                 exit: 1250,
                }}
             classNames="transitionable-actionBox" 
-            onEntered={() => endTransition(index)}
+            onEntered={() => {
+              setTimeout(() => {
+                endTransition(index)
+              }, 25)
+            }}
         >
             <div className="actionBox">
             {`${content}`}


### PR DESCRIPTION
Added animation frame timeout to ensure that state cycles between isAnimating: true <-> false without reconcilliation accidentally passing over the state cycle, causing bet/fold animation notifications to occasionally not appear